### PR TITLE
Choose assignee w/o case sensitivity to the author's name

### DIFF
--- a/bot/actions/autoassign/autoassign.go
+++ b/bot/actions/autoassign/autoassign.go
@@ -2,6 +2,7 @@ package autoassign
 
 import (
 	"math/rand"
+	"strings"
 
 	"github.com/bivas/rivi/bot"
 	"github.com/bivas/rivi/util"
@@ -60,7 +61,7 @@ func (a *action) Apply(config bot.Configuration, meta bot.EventData) {
 }
 
 func (a *action) randomUsers(config bot.Configuration, meta bot.EventData, lookupRoles []string) []string {
-	possibleSet := util.StringSet{}
+	possibleSet := util.StringSet{Transformer: strings.ToLower}
 	possibleSet.AddAll(config.GetRoleMembers(lookupRoles...)).Remove(meta.GetOrigin())
 	for _, assignee := range meta.GetAssignees() {
 		possibleSet.Remove(assignee)

--- a/bot/actions/autoassign/autoassign_test.go
+++ b/bot/actions/autoassign/autoassign_test.go
@@ -57,6 +57,20 @@ func TestActionApplyWithoutOrigin(t *testing.T) {
 	}
 }
 
+func TestActionApplyWithoutOriginCaseInsensitive(t *testing.T) {
+	action := action{rule: &rule{Require: 1, FromRoles: []string{"default"}}}
+	roles := make(map[string][]string)
+	roles["default"] = []string{"usEr1", "user2"}
+	for i := 0; i < 10; i++ {
+		config := &mock.MockConfiguration{RoleMembers: roles}
+		meta := &mock.MockEventData{Assignees: []string{}, Origin: "USER1"}
+		action.Apply(config, meta)
+		assert.Len(t, meta.AddedAssignees, 1, "assignment")
+		assert.NotContains(t, meta.AddedAssignees, "user1", "matched group")
+		assert.Contains(t, meta.AddedAssignees, "user2", "matched group")
+	}
+}
+
 func TestActionApplyHasAssignee(t *testing.T) {
 	action := action{rule: &rule{Require: 1, FromRoles: []string{"group"}}}
 	roles := make(map[string][]string)


### PR DESCRIPTION
Currently a user may become assigned to their own PR if their username (as appears in the webhook body) has different capitalization than that in the config.